### PR TITLE
fix: install pyyaml in image signing workflow

### DIFF
--- a/.github/workflows/test-image-signing.yml
+++ b/.github/workflows/test-image-signing.yml
@@ -32,13 +32,14 @@ jobs:
         uses: sigstore/cosign-installer@v3
         with:
           cosign-release: 'v2.2.0'
-          
-      - name: Validate Kyverno Policies
-        run: |
+
+      - name: Install validation dependencies
+        run: pip install pyyaml
+
       - name: Validate Kyverno Policies
         run: |
           echo "Validating Kyverno policies..."
-          
+
           # Simple YAML syntax validation
           for policy in k8s/policies/*.yaml; do
             if [[ "$policy" == *"README.md"* ]]; then


### PR DESCRIPTION
## Summary
- install PyYAML dependency for kyverno policy validation
- remove duplicate step in image signing workflow

## Testing
- `npm test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a758545a6083209a90c528239080de